### PR TITLE
Restore missing Apple iMessage changelog entries

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -663,6 +663,41 @@
     <td>Added official Signal documentation links to the Signal column and updated security audit references</td>
     <td>Links to official Signal support pages, protocol specifications, and blog posts added to 18 cells; added PQXDH formal verification (USENIX 2024) to audit row</td>
 </tr>
+<tr>
+    <td>04/26</td>
+    <td>Updated "Infrastructure jurisdiction" for Apple iMessage from "USA (Ireland and Denmark planned); iMessage runs on AWS and Google Cloud" to "USA, Ireland, Denmark; iMessage uses AWS and Google Cloud for storage"</td>
+    <td>Apple's Ireland and Denmark data centers are now operational (were previously "planned")</td>
+</tr>
+<tr>
+    <td>04/26</td>
+    <td>Updated "Cryptographic primitives" for Apple iMessage from "P-256 ECDH &amp; Kyber-768/1024 / AES-256 / HMAC-SHA384" to "P-256 ECDH &amp; Kyber-1024 / AES-256 CTR / HKDF-SHA384"</td>
+    <td>Per Apple's PQ3 blog and Stebila's formal analysis, PQ3 uses Kyber-1024 (not 768), AES-256 in CTR mode, and HKDF-SHA384</td>
+</tr>
+<tr>
+    <td>04/26</td>
+    <td>Changed "Does the app allow local authentication when opening it?" for Apple iMessage from "No" to "Yes (iOS 18+)"</td>
+    <td>iOS 18 added system-wide app locking with Face ID/Touch ID/passcode which works on the Messages app</td>
+</tr>
+<tr>
+    <td>04/26</td>
+    <td>Updated "Are messages encrypted when backed up to the cloud?" for Apple iMessage from "Yes" (red) to "Yes, but backup key is escrowed by Apple unless Advanced Data Protection is enabled" (yellow)</td>
+    <td>Clarifies that iCloud Backup is only fully end-to-end encrypted when the opt-in Advanced Data Protection feature (released December 2022) is enabled</td>
+</tr>
+<tr>
+    <td>04/26</td>
+    <td>Changed "Have there been a recent code audit and an independent security analysis?" for Apple iMessage from "No" to "Somewhat" with references to Stebila (2024) and Linker/Basin/Sasse USENIX Security 2025 formal analyses of PQ3</td>
+    <td>Multiple independent formal verifications of Apple's PQ3 protocol have been published since the last update, though broader independent analysis of the full iMessage stack remains limited</td>
+</tr>
+<tr>
+    <td>04/26</td>
+    <td>Added official Apple documentation links to the Apple iMessage column</td>
+    <td>Links to official Apple support pages, security blog, and legal process guidelines added to 11 cells to support claims</td>
+</tr>
+<tr>
+    <td>04/26</td>
+    <td>Updated Apple iMessage "reasons not recommended" list entry from "No independent, recent code audit and security analysis" to "More comprehensive code audit and security analysis"</td>
+    <td>Reflects that independent formal analyses of PQ3 now exist (Stebila 2024, USENIX 2025), while more comprehensive analysis of the full iMessage stack remains desirable</td>
+</tr>
 
 
          </tbody>


### PR DESCRIPTION
## Summary

Restores 7 Apple iMessage changelog entries that were dropped during conflict resolution when markxwilliams/securemess#23 (Signal column) merged after markxwilliams/securemess#24 (iMessage column). The corresponding `index.html` cell changes from markxwilliams/securemess#24 are already present on `main` — only the `changelog.html` rows were lost.

Restored entries:

1. Infrastructure jurisdiction (USA, Ireland, Denmark)
2. Cryptographic primitives (Kyber-1024 / AES-256 CTR / HKDF-SHA384)
3. Local authentication (iOS 18+)
4. Cloud backup (Advanced Data Protection nuance)
5. Code audit row softened to "Somewhat" with Stebila 2024 + USENIX 2025 references
6. Official Apple documentation links added to 11 cells
7. "Reasons not recommended" entry updated to "More comprehensive code audit and security analysis"

## Test plan

- [ ] Open `changelog.html` and confirm the 7 new entries appear in chronological order under 04/26
- [ ] Cross-reference each entry against the corresponding cell in `index.html`