### PR TITLE
Verify Threema column: refresh ownership, audits, Ibex, links

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -723,6 +723,36 @@
     <td>Updated Facebook Messenger "reasons not recommended" list entry from "No independent &amp; recent code audit and security analysis" to "More comprehensive code audit and security analysis"</td>
     <td>Reflects that some independent analysis now exists (Labyrinth formal verification) while more comprehensive analysis of the full E2EE stack remains desirable</td>
 </tr>
+<tr>
+    <td>04/26</td>
+    <td>Updated "Funding" for Threema from "User pays / Afinum Management AG" to "User pays / Comitis Capital GmbH (formerly Afinum, 2020–2026)"</td>
+    <td>Threema was acquired by Comitis Capital GmbH in January 2026, replacing Afinum Management AG as the majority owner</td>
+</tr>
+<tr>
+    <td>04/26</td>
+    <td>Updated "Cryptographic primitives" for Threema to note that the Ibex protocol adds a perfect forward secrecy layer on top of Curve25519/XSalsa20/Poly1305-AES</td>
+    <td>The Ibex forward secrecy protocol was rolled out in Threema 5.0 (Android, November 2022) and is now the default for new chats</td>
+</tr>
+<tr>
+    <td>04/26</td>
+    <td>Added Ibex blog link to "Does the app enforce perfect forward secrecy?" for Threema</td>
+    <td>Provides a direct reference to Threema's official explanation of the Ibex protocol that delivers PFS and post-compromise security</td>
+</tr>
+<tr>
+    <td>04/26</td>
+    <td>Updated "Have there been a recent code audit and an independent security analysis?" for Threema from "Yes (October, 2020)" to references for ETH Zürich (USENIX Security 2023), the Ibex formal proof (2023), and the Cure53 Threema Desktop 2.0 audit (January 2024)</td>
+    <td>Multiple newer independent analyses of Threema have been published since 2020, including Paterson/Scarlata/Truong's "Three Lessons from Threema" at USENIX Security 2023, Gerhart/Rösler/Schröder's formal security proof of the Ibex protocol (2023), and Cure53's audit of Threema Desktop 2.0 (January 2024)</td>
+</tr>
+<tr>
+    <td>04/26</td>
+    <td>Fixed a typographical error in the Threema "Does the app encrypt data on the device?" cell ("set in the app)s" → "set in the app)")</td>
+    <td>Removes a stray trailing character</td>
+</tr>
+<tr>
+    <td>04/26</td>
+    <td>Added official Threema documentation links to the Threema column</td>
+    <td>Links to Threema's server-location FAQ, ownership FAQ, cryptography whitepaper, Ibex blog post, open-source page, Threema ID FAQ, and Threema Safe FAQ added to supporting cells</td>
+</tr>
 
 
          </tbody>

--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
                 <td class="red">UK (and potentially all jurisdictions, given it's a decentralised messaging platform)</td>
                 <td class="red">USA</td>
                 <td class="red">UK, Singapore, USA, and Finland</td>
-                <td class="yellow">Switzerland</td>
+                <td class="yellow"><a href="https://threema.com/en/faq/server_location">Switzerland</a></td>
                 <td class="red">USA</td>
                 <td class="red">USA (unsure of other locations)</td>
                 <td class="red">USA (unsure of other locations)</td>
@@ -251,7 +251,7 @@
                 <td class="green">New Vector Limited</td>
                 <td class="green">Signal Foundation (Brian Acton) <br /><br> User donations <br /><br> Historically: Freedom of the Press Foundation, The Knight Foundation, The Shuttleworth Foundation, The Open Technology Fund</td>
                 <td class="green">Pavel Durov</td>
-                <td class="green">User pays / Afinum Management AG</td>
+                <td class="green"><a href="https://threema.com/en/faq/ownership">User pays / Comitis Capital GmbH (formerly Afinum, 2020–2026)</a></td>
                 <td class="green">Rakuten <br /><br> Friends and family of Talmon Marco (very unclear)</td>
                 <td class="red">Facebook</td>
                 <td class="red">Amazon <br /><br> the CIA</td>
@@ -302,7 +302,7 @@
                 <td class="green">Yes</td>
                 <td class="green"><a href="https://support.signal.org/hc/en-us/articles/360007062792">Yes</a></td>
                 <td class="red">No</td>
-                <td class="green">Yes</td>
+                <td class="green"><a href="https://threema.com/press-files/2_documentation/cryptography_whitepaper.pdf">Yes</a></td>
                 <td class="green">Yes (if device supports it)</td>
                 <td class="green">Yes (if device supports it)</td>
                 <td class="green">Yes</td>
@@ -319,7 +319,7 @@
                 <td class="yellow">Curve25519 / AES-256 / HMAC-SHA256</td>
                 <td class="green"><a href="https://signal.org/docs/specifications/pqxdh/">Curve25519 & Kyber-1024 / AES-256 / HMAC-SHA256/512</a></td>
                 <td class="yellow">RSA 2048 / AES 256 / SHA-256</td>
-                <td class="yellow">Curve25519 256 / XSalsa20 256 / Poly1305-AES 128</td>
+                <td class="yellow"><a href="https://threema.com/en/blog/posts/ibex-en">Curve25519 256 / XSalsa20 256 / Poly1305-AES 128 (Ibex protocol adds PFS layer)</a></td>
                 <td class="yellow">Curve25519 256 / Salsa20 128 / HMAC-SHA256</td>
                 <td class="yellow">Curve25519 / AES-256 / HMAC-SHA256</td>
                 <td class="yellow">ECDH512 / AES-256 / HMAC-SHA256</td>
@@ -336,7 +336,7 @@
                 <td class="green">Yes (clients Element / Riot, server/API matrix.org)</td>
                 <td class="green"><a href="https://github.com/signalapp">Yes</a> (anti-spam module excluded)</td>
                 <td class="yellow">No (clients and API only)</td>
-                <td class="yellow">No (apps only)</td>
+                <td class="yellow"><a href="https://threema.com/en/open-source">No (apps only)</a></td>
                 <td class="red">No</td>
                 <td class="red">No</td>
                 <td class="red">No</td>
@@ -370,7 +370,7 @@
                 <td class="green">Yes</td>
                 <td class="red"><a href="https://support.signal.org/hc/en-us/articles/360007318691">No</a></td>
                 <td class="red">No</td>
-                <td class="green">Yes</td>
+                <td class="green"><a href="https://threema.com/en/faq/threema_id">Yes</a></td>
                 <td class="red">No</td>
                 <td class="red">No</td>
                 <td class="green">Yes</td>
@@ -506,7 +506,7 @@
                 <td class="green">Yes</td>
                 <td class="green"><a href="https://signal.org/docs/specifications/doubleratchet/">Yes</a></td>
                 <td class="red">No (session keys do change after being used 100 times)</td>
-                <td class="green">Yes</td>
+                <td class="green"><a href="https://threema.com/en/blog/posts/ibex-en">Yes</a></td>
                 <td class="green">Yes</td>
                 <td class="green">Yes</td>
                 <td class="green">Yes</td>
@@ -574,7 +574,7 @@
                 <td class="green">Yes</td>
                 <td class="green">Yes</td>
                 <td class="white"></td>
-                <td class="green">iOS: Yes (if passphrase enabled); Android: Yes (if master key set in the app)s</td>
+                <td class="green">iOS: Yes (if passphrase enabled); Android: Yes (if master key set in the app)</td>
                 <td class="white"></td>
                 <td class="white"></td>
                 <td class="green">iOS: Yes (if passphrase enabled); Android: Yes (unsure of function)</td>
@@ -608,7 +608,7 @@
                 <td class="green">Yes</td>
                 <td class="yellow">N/A, Signal is excluded from iCloud/iTunes & Android backups; Signal offers an opt-in, <a href="https://support.signal.org/hc/en-us/articles/360007059752">end-to-end encrypted backup service</a></td>
                 <td class="white"></td>
-                <td class="green">Yes</td>
+                <td class="green"><a href="https://threema.com/en/faq/threema_safe">Yes</a></td>
                 <td class="white"></td>
                 <td class="green">iOS: Yes / Android: Yes</td>
                 <td class="white">N/A, Wickr is excluded from iCloud/iTunes & Android backups</td>
@@ -642,7 +642,7 @@
                 <td class="red">No (Matrix's encryption library reviewed by an independent party)</td>
                 <td class="green">Yes (<a href="https://community.signalusers.org/t/overview-of-third-party-security-audits/13243">many in the last few years</a>; <a href="https://www.usenix.org/conference/usenixsecurity24/presentation/bhargavan">PQXDH formal verification, 2024</a>)</td>
                 <td class="green">Yes (November, 2015)</td>
-                <td class="green">Yes (October, 2020)</td>
+                <td class="green">Yes (<a href="https://breakingthe3ma.app/">ETH Zürich, USENIX 2023</a>; <a href="https://threema.com/press-files/2_documentation/security_analysis_ibex_2023.pdf">Ibex formal proof, 2023</a>; <a href="https://threema.com/press-files/2_documentation/audit-report-threema-desktop-01-2024.pdf">Cure53 Desktop, 2024</a>)</td>
                 <td class="red">No</td>
                 <td class="red">No</td>
                 <td class="green">Yes (August, 2014)</td>


### PR DESCRIPTION
## Summary

Systematic verification of every claim made in the Threema column of the comparison table. Most claims still hold, but several were stale and have been refreshed against current (2024–2026) sources.

### Value changes

- **Funding** — `User pays / Afinum Management AG` → `User pays / Comitis Capital GmbH (formerly Afinum, 2020–2026)`. Threema was acquired by Comitis Capital GmbH in January 2026.
- **Cryptographic primitives** — annotated to note that the [Ibex protocol](https://threema.com/en/blog/posts/ibex-en) layers perfect forward secrecy on top of the existing Curve25519/XSalsa20/Poly1305-AES primitives.
- **Perfect forward secrecy** — added link to Threema's official Ibex blog post.
- **Recent code audit / independent security analysis** — replaced the lone "October, 2020" reference with three newer independent analyses:
  - [ETH Zürich, *Three Lessons From Threema*, USENIX Security 2023](https://breakingthe3ma.app/)
  - [Gerhart/Rösler/Schröder, *Ibex* formal proof, 2023](https://threema.com/press-files/2_documentation/security_analysis_ibex_2023.pdf)
  - [Cure53, Threema Desktop 2.0 audit, January 2024](https://threema.com/press-files/2_documentation/audit-report-threema-desktop-01-2024.pdf)

### Cleanup

- Fixed a long-standing typo on the Threema "encrypt data on device" cell (`set in the app)s` → `set in the app)`).

### Documentation links

Added official Threema documentation links to ~7 supporting cells (server-location FAQ, ownership FAQ, cryptography whitepaper, Ibex blog post, open-source page, Threema ID FAQ, Threema Safe FAQ).

### Items intentionally not changed

- **Self-destructing messages** — kept as `No`.
- All other Threema cells were verified as still accurate.

Each change is also recorded in `changelog.html`.

## Test plan

- [ ] Open `index.html` and confirm the Threema column renders correctly with the new links and labels.
- [ ] Confirm cell counts on every data row remain at 14.
- [ ] Spot-check the Ibex, Comitis, ETH Zürich, and Cure53 links.
- [ ] Open `changelog.html` and confirm the new entries render.
