### PR TITLE
Verify and update Wire column: fix data corruption, add official links and audit reports

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -855,6 +855,31 @@
     <td>Added official audit links to "Have there been a recent code audit and an independent security analysis?" for Session</td>
     <td>Links added to Session's blog post (getsession.org/blog/session-code-audit) and Quarkslab's full report (blog.quarkslab.com) for the April 2021 Quarkslab security assessment</td>
 </tr>
+<tr>
+    <td>04/26</td>
+    <td>Fixed "Infrastructure jurisdiction" for Wire from Session's data (de-centralised servers / Canada) to Wire's actual infrastructure</td>
+    <td>Wire uses centralised EU servers in Germany and Ireland hosted on AWS; the previous cell contained Session's data by mistake</td>
+</tr>
+<tr>
+    <td>04/26</td>
+    <td>Added transparency report link to "Does the company provide a transparency report?" for Wire</td>
+    <td>Links to wire.com/en/transparency-report</td>
+</tr>
+<tr>
+    <td>04/26</td>
+    <td>Added Phase 1 audit PDF link to "Cryptographic primitives" for Wire</td>
+    <td>Links to the Kudelski Security &amp; X41 D-Sec Proteus/Cryptobox protocol audit (February 2017) which documents the Curve25519 / ChaCha20 / HMAC-SHA256 cryptographic stack</td>
+</tr>
+<tr>
+    <td>04/26</td>
+    <td>Added GitHub link to "Are the app and server completely open source?" for Wire</td>
+    <td>Links to github.com/wireapp</td>
+</tr>
+<tr>
+    <td>04/26</td>
+    <td>Updated "Have there been a recent code audit and an independent security analysis?" for Wire from "Yes (March, 2018)" to include both Phase 1 (Kudelski Security &amp; X41 D-Sec, February 2017) and Phase 2 (X41 D-Sec, March 2018) audits with links</td>
+    <td>Phase 1 covered the Proteus/Cryptobox protocol; Phase 2 covered application-level security (iOS/Android/Web); both audits now linked directly</td>
+</tr>
          </tbody>
 </table>
     </div>

--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
                 <td class="red">USA</td>
                 <td class="red">USA (unsure of other locations)</td>
                 <td class="red">USA (unsure of other locations)</td>
-                <td class="red">Messages: Worldwide (uses de-centralised servers)<br /><br />Attachments: Centralised server in Canada</td>
+                <td class="red">EU (Germany and Ireland, hosted on AWS)</td>
                 <td class="red">Worldwide (uses de-centralised servers)</td>
                 <td class="red">Worldwide (uses de-centralised servers)</td>
                 <td class="red">USA (Portland, OR and Atlanta, GA on-prem; GCP and AWS US regions)</td>
@@ -204,7 +204,7 @@
                 <td class="red">No</td>
                 <td class="red">No</td>
                 <td class="green">Yes</td>
-                <td class="green">Yes</td>
+                <td class="green"><a href="https://wire.com/en/transparency-report">Yes</a></td>
                 <td class="green"><a href="https://session.foundation/transparency-reports">Yes</a></td>
                 <td class="green"><a href="https://simplex.chat/transparency/">Yes</a></td>
                 <td class="green"><a href="https://transparency.x.com/en">Yes</a></td>
@@ -323,7 +323,7 @@
                 <td class="yellow">Curve25519 256 / Salsa20 128 / HMAC-SHA256</td>
                 <td class="yellow">Curve25519 / AES-256 / HMAC-SHA256</td>
                 <td class="yellow">ECDH512 / AES-256 / HMAC-SHA256</td>
-                <td class="yellow">Curve25519 / ChaCha20 / HMAC-SHA256</td>
+                <td class="yellow"><a href="https://wire-docs.wire.com/download/Wire+Audit+Report.pdf">Curve25519 / ChaCha20 / HMAC-SHA256</a></td>
                 <td class="green"><a href="https://getsession.org/blog/session-protocol-technical-information">X25519 / XSalsa20 256 / Poly1305</a></td>
                 <td class="green"><a href="https://simplex.chat/blog/20240314-simplex-chat-v5-6-quantum-resistance-signal-double-ratchet-algorithm.html">Curve25519 &amp; sntrup761 1158 / XSalsa20 256 / Poly1305</a></td>
                 <td class="red"><a href="https://blog.cryptographyengineering.com/2025/06/09/a-bit-more-on-twitter-xs-new-encrypted-messaging/">libsodium (X25519 / XSalsa20-Poly1305); Juicebox (threshold OPRF + secret-sharing) for key storage; no PFS</a></td>
@@ -340,7 +340,7 @@
                 <td class="red">No</td>
                 <td class="red">No</td>
                 <td class="red">No</td>
-                <td class="green">Yes</td>
+                <td class="green"><a href="https://github.com/wireapp">Yes</a></td>
                 <td class="green"><a href="https://github.com/session-foundation">Yes</a></td>
                 <td class="green"><a href="https://github.com/simplex-chat/simplex-chat">Yes</a></td>
                 <td class="red">No</td>
@@ -646,7 +646,7 @@
                 <td class="red">No</td>
                 <td class="red">No</td>
                 <td class="green">Yes (August, 2014)</td>
-                <td class="green">Yes (March, 2018)</td>
+                <td class="green">Yes (<a href="https://wire-docs.wire.com/download/Wire+Audit+Report.pdf">Kudelski Security &amp; X41 D-Sec, February 2017</a>; <a href="https://www.x41-dsec.de/security/report/2018/03/06/projects-x41-wire-phase2/">X41 D-Sec, March 2018</a>)</td>
                 <td class="green">Yes (<a href="https://getsession.org/blog/session-code-audit">Quarkslab, April 2021</a>; <a href="https://blog.quarkslab.com/audit-of-session-secure-messaging-application.html">full report</a>)</td>
                 <td class="green">Yes (<a href="https://simplex.chat/blog/20221108-simplex-chat-v4.2-security-audit-new-website.html">Trail of Bits, November 2022</a>; <a href="https://simplex.chat/blog/20241014-simplex-network-v6-1-security-review-better-calls-user-experience.html">Trail of Bits design review, October 2024</a>)</td>
                 <td class="red">No</td>


### PR DESCRIPTION
- Fix infrastructure jurisdiction cell which incorrectly contained Session's
  decentralised-server data; Wire uses centralised EU servers in Germany and
  Ireland (hosted on AWS)
- Add Wire transparency report link (wire.com/en/transparency-report)
- Add Phase 1 audit PDF link to cryptographic primitives cell
  (Kudelski Security & X41 D-Sec Proteus/Cryptobox audit, Feb 2017)
- Add GitHub link to open source cell (github.com/wireapp)
- Expand code audit cell from bare "Yes (March, 2018)" to include both
  Phase 1 (Kudelski Security & X41 D-Sec, Feb 2017) and Phase 2
  (X41 D-Sec, March 2018) audits with direct links to each report
- Add 5 corresponding changelog entries dated 04/26

https://claude.ai/code/session_01Jd99HX7f6m1ssxmYQBoAjo