### PR TITLE
Upgrade Bootstrap to 5.3.8 and fix mobile first-column sticky bug

### DIFF
--- a/matrix-style.css
+++ b/matrix-style.css
@@ -53,11 +53,13 @@ thead img {
 	transform: scale(var(--iconSize));
 }
 th {
-	top: 0;
 	background-color: #37474f;
 	color: #FFF;
 	font-weight: bold;
 	min-height: 3rem;
+}
+thead th {
+	top: 0;
 }
 th:first-child {
 	max-width: 200px;


### PR DESCRIPTION
## Summary

- Upgrades Bootstrap CDN from 5.3.3 to 5.3.8 across all five pages (`index.html`, `about.html`, `contact.html`, `changelog.html`, `ratings.html`), with updated SRI integrity hashes computed from the npm package
- Fixes a mobile bug where first-column row labels merged into the header cell when scrolling down the table

## Bug fix detail

`th { top: 0 }` in `matrix-style.css` applied `position: sticky; top: 0` to every `th` element — including the row-label cells in the first column of `tbody`. When scrolling down on mobile, those cells pinned to the top of the scroll container and overlapped the header row, appearing to merge with it.

The fix scopes `top: 0` to `thead th` only, so row labels stay sticky to the left (for horizontal scrolling) but scroll away normally when scrolling vertically.

## Test plan

- [ ] On mobile (or narrow viewport), scroll the table horizontally — first-column labels remain pinned to the left edge
- [ ] On mobile, scroll the table vertically — header row sticks at the top, row labels scroll away normally with no merging
- [ ] Verify Bootstrap 5.3.8 loads correctly on all five pages (check browser console for SRI errors)

https://claude.ai/code/session_01YXkSbgyd8rySMQSjWNthdQ