### PR TITLE
Remove sticky-left from Messenger header cell on mobile

### DIFF
--- a/matrix-style.css
+++ b/matrix-style.css
@@ -236,6 +236,9 @@ color: #FFF; /* Text color */
 	tbody th:first-child {
 		position: static !important;
 	}
+	thead th:first-child {
+		left: auto;
+	}
 }
 @media all and (max-height: 667px) {
 	/* FORM/FILTER BUTTON */

--- a/matrix-style.css
+++ b/matrix-style.css
@@ -236,6 +236,9 @@ color: #FFF; /* Text color */
 	tbody th:first-child {
 		top: auto !important;
 	}
+	thead th:first-child {
+		z-index: 3;
+	}
 }
 @media all and (max-height: 667px) {
 	/* FORM/FILTER BUTTON */

--- a/matrix-style.css
+++ b/matrix-style.css
@@ -234,10 +234,7 @@ color: #FFF; /* Text color */
 }
 @media all and (max-width: 1024px) {
 	tbody th:first-child {
-		position: static !important;
-	}
-	thead th:first-child {
-		left: auto;
+		top: auto !important;
 	}
 }
 @media all and (max-height: 667px) {


### PR DESCRIPTION
thead th:first-child had left: 0, keeping it pinned to the left edge when scrolling horizontally. On mobile the first column is no longer sticky, so the Messenger cell should scroll with it. Override left: auto in the 1024px breakpoint — it still sticks to the top via top: 0.

https://claude.ai/code/session_01YXkSbgyd8rySMQSjWNthdQ