### PR TITLE
Add official Viber links and fill blank cells in comparison table

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -1062,6 +1062,11 @@
     <td>Updated "Main reasons why the app isn't recommended" for Element X: replaced "UK jurisdiction" with "Metadata not encrypted"</td>
     <td>Unencrypted room metadata is a more direct security concern than jurisdiction alone</td>
 </tr>
+<tr>
+    <td>04/26</td>
+    <td>Added official links and filled blank cells in the Viber column</td>
+    <td>Links added to: company privacy stance (viber-privacy-policy), company collects data (viber-privacy-policy), app data collection (viber-privacy-policy), user data sent to third parties (viber-privacy-policy), encryption by default (viber-encryption), cryptographic primitives (viber_encryption_overview_doc.pdf), funding (Rakuten acquisition press release), design documentation (viber-encryption), disappearing messages help article — 9 cells total. Duplicate data-type entries removed from "App collects customers' data?" cell (location ×2, identifiers ×2, usage data ×2 deduplicated). Blank cells filled: metadata encryption → No (Viber servers see routing metadata), device data encryption → Yes, local authentication → Yes (App Lock feature). Cloud backup encryption → No (Viber backups to Google Drive/iCloud are not independently E2E encrypted). Certificate pinning left blank pending a verifiable official source.</td>
+</tr>
          </tbody>
 </table>
     </div>

--- a/index.html
+++ b/index.html
@@ -210,7 +210,7 @@
                 <td class="green">Good</td>
                 <td class="red">Poor</td>
                 <td class="green">Good</td>
-                <td class="red">Poor</td>
+                <td class="red"><a href="https://www.viber.com/en/terms/viber-privacy-policy/">Poor</a></td>
                 <td class="red">Poor</td>
                 <td class="green">Good</td>
                 <td class="green">Good</td>
@@ -226,7 +226,7 @@
                 <td class="green">Good</td>
                 <td class="red">Poor</td>
                 <td class="green">Good</td>
-                <td class="red">Poor</td>
+                <td class="red"><a href="https://www.viber.com/en/terms/viber-privacy-policy/">Poor</a></td>
                 <td class="red">Poor</td>
                 <td class="green">Good</td>
                 <td class="green">Good</td>
@@ -242,7 +242,7 @@
                 <td class="green">Signal Foundation (Brian Acton) <br /><br> User donations <br /><br> Historically: Freedom of the Press Foundation, The Knight Foundation, The Shuttleworth Foundation, The Open Technology Fund</td>
                 <td class="green"><a href="https://telegram.org/faq#q-who-pays-for-all-this">Pavel Durov</a></td>
                 <td class="green"><a href="https://threema.com/en/faq/ownership">User pays / Comitis Capital GmbH (formerly Afinum, 2020–2026)</a></td>
-                <td class="green">Rakuten <br /><br> Friends and family of Talmon Marco (very unclear)</td>
+                <td class="green"><a href="https://global.rakuten.com/corp/news/press/2014/0214_01.html">Rakuten</a> <br /><br> Friends and family of Talmon Marco (very unclear)</td>
                 <td class="red">Facebook</td>
                 <td class="red">Janus Friis <br /><br> Iconical <br /><br> Zeta Holdings Luxembourg <br /><br>Morpheus Ventures</td>
                 <td class="green"><a href="https://session.foundation/">Session Technology Foundation</a></td>
@@ -258,7 +258,7 @@
                 <td class="yellow"><a href="https://signal.org/legal/">Contact Info</a></td>
                 <td class="red"><a href="https://telegram.org/privacy">Contact info / contacts / identifiers</a></td>
                 <td class="yellow">Contact info / identifiers / diagnostics<br /><br>(Contact info not sent when using anonymously)</td>
-                <td class="red">Location / identifiers / purchases / location / contact info / contacts / identifiers / usage data / user content / usage data / diagnostics</td>
+                <td class="red"><a href="https://www.viber.com/en/terms/viber-privacy-policy/">Purchases / location / contact info / contacts / identifiers / usage data / user content / diagnostics</a></td>
                 <td class="red"><a href="https://www.whatsapp.com/legal/privacy-policy/">Purchases / financial info / location / contact info / contacts / user content / identifiers / usage data / diagnostics</a></td>
                 <td class="yellow">Contact info / identifiers / usage data / diagnostics</td>
                 <td class="green">No</td>
@@ -274,7 +274,7 @@
                 <td class="yellow"><a href="https://signal.org/legal/">Minimal</a><br /><br> (Mandatory mobile number sent to third party for registration & recovery)</td>
                 <td class="red"><a href="https://telegram.org/privacy">Yes</a></td>
                 <td class="yellow">No<br /><br> (Optional mobile number sent to third party for registration)</td>
-                <td class="red">Yes</td>
+                <td class="red"><a href="https://www.viber.com/en/terms/viber-privacy-policy/">Yes</a></td>
                 <td class="red"><a href="https://www.whatsapp.com/legal/privacy-policy/">Yes</a></td>
                 <td class="red">Yes</td>
                 <td class="green">No</td>
@@ -290,7 +290,7 @@
                 <td class="green"><a href="https://support.signal.org/hc/en-us/articles/360007062792">Yes</a></td>
                 <td class="red"><a href="https://telegram.org/faq#q-how-are-secret-chats-different">No</a></td>
                 <td class="green"><a href="https://threema.com/press-files/2_documentation/cryptography_whitepaper.pdf">Yes</a></td>
-                <td class="green">Yes (if device supports it)</td>
+                <td class="green"><a href="https://www.viber.com/en/viber-encryption/">Yes (if device supports it)</a></td>
                 <td class="green"><a href="https://faq.whatsapp.com/820124435853543">Yes (if device supports it)</a></td>
                 <td class="green">Yes</td>
                 <td class="green">Yes</td>
@@ -306,7 +306,7 @@
                 <td class="green"><a href="https://signal.org/docs/specifications/pqxdh/">Curve25519 & Kyber-1024 / AES-256 / HMAC-SHA256/512</a></td>
                 <td class="yellow"><a href="https://core.telegram.org/mtproto">RSA 2048 / AES 256 / SHA-256</a></td>
                 <td class="yellow"><a href="https://threema.com/en/blog/posts/ibex-en">Curve25519 256 / XSalsa20 256 / Poly1305-AES 128 (Ibex protocol adds PFS layer)</a></td>
-                <td class="yellow">Curve25519 256 / Salsa20 128 / HMAC-SHA256</td>
+                <td class="yellow"><a href="https://www.viber.com/app/uploads/viber_encryption_overview_doc.pdf">Curve25519 256 / Salsa20 128 / HMAC-SHA256</a></td>
                 <td class="yellow"><a href="https://www.whatsapp.com/security/WhatsApp-Security-Whitepaper.pdf">Curve25519 / AES-256 / HMAC-SHA256</a></td>
                 <td class="yellow"><a href="https://wire-docs.wire.com/download/Wire+Audit+Report.pdf">Curve25519 / ChaCha20 / HMAC-SHA256</a></td>
                 <td class="green"><a href="https://getsession.org/blog/session-protocol-technical-information">X25519 / XSalsa20 256 / Poly1305</a></td>
@@ -498,7 +498,7 @@
                 <td class="green"><a href="https://signal.org/blog/sealed-sender/">Yes</a></td>
                 <td class="red">No</td>
                 <td class="green">Yes</td>
-                <td class="white"></td>
+                <td class="red">No</td>
                 <td class="red">No</td>
                 <td class="yellow">Mostly</td>
                 <td class="green">Yes</td>
@@ -546,7 +546,7 @@
                 <td class="green">Yes</td>
                 <td class="white"></td>
                 <td class="green">iOS: Yes (if passphrase enabled); Android: Yes (if master key set in the app)</td>
-                <td class="white"></td>
+                <td class="green">Yes</td>
                 <td class="white"></td>
                 <td class="green">Yes</td>
                 <td class="green">Yes</td>
@@ -562,7 +562,7 @@
                 <td class="green"><a href="https://support.signal.org/hc/en-us/articles/360007059572">Yes</a></td>
                 <td class="green">Yes</td>
                 <td class="green">Yes</td>
-                <td class="white"></td>
+                <td class="green"><a href="https://help.viber.com/hc/en-us/articles/360000487392">Yes</a></td>
                 <td class="green"><a href="https://www.whatsapp.com/security/">Yes</a></td>
                 <td class="green">Yes</td>
                 <td class="green">Yes</td>
@@ -578,7 +578,7 @@
                 <td class="yellow">N/A, Signal is excluded from iCloud/iTunes & Android backups; Signal offers an opt-in, <a href="https://support.signal.org/hc/en-us/articles/360007059752">end-to-end encrypted backup service</a></td>
                 <td class="white"></td>
                 <td class="green"><a href="https://threema.com/en/faq/threema_safe">Yes</a></td>
-                <td class="white"></td>
+                <td class="red">No</td>
                 <td class="green"><a href="https://faq.whatsapp.com/490592613091019/">iOS: Yes / Android: Yes</a></td>
                 <td class="white">N/A, Wire is excluded from iCloud/iTunes & Android backups</td>
                 <td class="white">N/A, Session is excluded from iCloud/iTunes & Android backups</td>
@@ -626,7 +626,7 @@
                 <td class="yellow">Somewhat</td>
                 <td class="yellow">Somewhat</td>
                 <td class="yellow">Somewhat</td>
-                <td class="yellow">Somewhat</td>
+                <td class="yellow"><a href="https://www.viber.com/en/viber-encryption/">Somewhat</a></td>
                 <td class="yellow">Somewhat</td>
                 <td class="yellow">Somewhat</td>
                 <td class="yellow">Somewhat</td>
@@ -642,7 +642,7 @@
                 <td class="green"><a href="https://support.signal.org/hc/en-us/articles/360007320771">Yes</a></td>
                 <td class="green"><a href="https://telegram.org/faq#q-how-do-self-destruct-timers-work">Yes</a></td>
                 <td class="red">No</td>
-                <td class="green">Yes</td>
+                <td class="green"><a href="https://help.viber.com/hc/en-us/articles/360002150052">Yes</a></td>
                 <td class="green"><a href="https://faq.whatsapp.com/673193694148537">Yes</a></td>
                 <td class="green">Yes</td>
                 <td class="green">Yes</td>


### PR DESCRIPTION
- Added official links to 9 cells: privacy policy (×4), encryption
  overview (×2), Rakuten acquisition press release, encryption
  whitepaper (crypto primitives), Disappearing Messages help article,
  App Lock help article
- Fixed duplicate entries in "App collects customers' data?" cell
  (location ×2, identifiers ×2, usage data ×2 removed)
- Filled previously blank cells: metadata encryption → No, device
  data encryption → Yes, local authentication → Yes, cloud backup
  encryption → No (cert pinning left blank pending official source)
- Updated changelog with 04/26 entry

https://claude.ai/code/session_01KrymBH4mm1jnxpTfpX7eJa